### PR TITLE
gecko-ffi overhaul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
+edition = "2018"
 name = "thin-vec"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Alexis Beingessner <a.beingessner@gmail.com>"]
 description = "a vec that takes up less space on the stack"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
* hopefully fixes auto bit handling on big endian platforms
* fixes seeming oversight in auto array reallocation
* revamps documentation to discuss gecko-ffi feature
* updates to rust 2018