### PR TITLE
Fix typo in repo url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ version = "0.2.2"
 authors = ["Alexis Beingessner <a.beingessner@gmail.com>"]
 description = "a vec that takes up less space on the stack"
 license = "MIT/Apache-2.0"
-repository = "https://github.com/gankro/thin-vec"
-homepage = "https://github.com/gankro/thin-vec"
+repository = "https://github.com/gankra/thin-vec"
+homepage = "https://github.com/gankra/thin-vec"
 readme = "README.md"
 
 [features]


### PR DESCRIPTION
Just was poking at the documentation and wanted to fix the repo link