### PR TITLE
Impl `Send` and `Sync` for `ThinVec<T>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,6 +398,8 @@ pub struct ThinVec<T> {
     boo: PhantomData<T>,
 }
 
+unsafe impl<T> Sync for ThinVec<T> {}
+unsafe impl<T> Send for ThinVec<T> {}
 
 /// Creates a `ThinVec` containing the arguments.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,8 +398,8 @@ pub struct ThinVec<T> {
     boo: PhantomData<T>,
 }
 
-unsafe impl<T> Sync for ThinVec<T> {}
-unsafe impl<T> Send for ThinVec<T> {}
+unsafe impl<T: Sync> Sync for ThinVec<T> {}
+unsafe impl<T: Send> Send for ThinVec<T> {}
 
 /// Creates a `ThinVec` containing the arguments.
 ///


### PR DESCRIPTION
`ThinVec<T>` is just `Vec<T>` except that it stores `len` and `cap` inline, so I don't see any reason why it cannot be `Send` and `Sync`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>