### PR TITLE
Fix provenance UB and alignment UB

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,9 +452,11 @@ impl<T> ThinVec<T> {
         let _ = padding::<T>();
 
         if cap == 0 {
-            ThinVec {
-                ptr: NonNull::new_unchecked(&EMPTY_HEADER as *const Header as *mut Header),
-                boo: PhantomData,
+            unsafe {
+                ThinVec {
+                    ptr: NonNull::new_unchecked(&EMPTY_HEADER as *const Header as *mut Header),
+                    boo: PhantomData,
+                }
             }
         } else {
             ThinVec {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,9 +247,22 @@ mod impl_details {
     }
 }
 
-/// The header of a ThinVec.
-///
-/// The _cap can be a bitfield, so use accessors to avoid trouble.
+// The header of a ThinVec.
+//
+// The _cap can be a bitfield, so use accessors to avoid trouble.
+//
+// In "real" gecko-ffi mode, the empty singleton will be aligned
+// to 8 by gecko. But in tests we have to provide the singleton
+// ourselves, and Rust makes it hard to "just" align a static.
+// To avoid messing around with a wrapper type around the
+// singleton *just* for tests, we just force all headers to be
+// aligned to 8 in this weird "zombie" gecko mode.
+//
+// This shouldn't affect runtime layout (padding), but it will
+// result in us asking the allocator to needlessly overalign
+// non-empty ThinVecs containing align < 8 types in
+// zombie-mode, but not in "real" geck-ffi mode. Minor.
+#[cfg_attr(all(feature = "gecko-ffi", any(test, miri)), repr(align(8)))]
 #[repr(C)]
 struct Header {
     _len: SizeType,
@@ -453,13 +466,42 @@ impl<T> ThinVec<T> {
         unsafe { self.ptr.as_ref() }
     }
     fn data_raw(&self) -> *mut T {
+        // `padding` contains ~static assertions against types that are
+        // incompatible with the current feature flags. Even if we don't
+        // care about its result, we should always call it before getting
+        // a data pointer to guard against invalid types!
+        let padding = padding::<T>();
+
+        // Although we ensure the data array is aligned when we allocate,
+        // we can't do that with the empty singleton. So when it might not
+        // be properly aligned, we substitute in the NonNull::dangling
+        // which *is* aligned.
+        //
+        // To minimize dynamic branches on `cap` for all accesses
+        // to the data, we include this guard which should only involve
+        // compile-time constants. Ideally this should result in the branch
+        // only be included for types with excessive alignment.
+        let empty_header_is_aligned = if cfg!(feature = "gecko-ffi") {
+            // in gecko-ffi mode `padding` will ensure this under
+            // the assumption that the header has size 8 and the
+            // static empty singleton is aligned to 8.
+            true
+        } else {
+            // In non-gecko-ffi mode, the empty singleton is just
+            // naturally aligned to the Header. If the Header is at
+            // least as aligned as T *and* the padding would have
+            // been 0, then one-past-the-end of the empty singleton
+            // *is* a valid data pointer and we can remove the
+            // `dangling` special case.
+            mem::align_of::<Header>() >= mem::align_of::<T>() && padding == 0
+        };
+
         unsafe {
-            if self.header().cap() == 0 {
-                // The empty header isn't well-aligned, just make an aligned one up
+            if !empty_header_is_aligned && self.header().cap() == 0 {
                 NonNull::dangling().as_ptr()
             } else {
-                // This could technically result in overflow, but padding would have to be absurdly large for this to occur.
-                let padding = padding::<T>();
+                // This could technically result in overflow, but padding
+                // would have to be absurdly large for this to occur.
                 let header_size = mem::size_of::<Header>();
                 let ptr = self.ptr.as_ptr() as *mut u8;
                 ptr.add(header_size + padding) as *mut T
@@ -1366,6 +1408,28 @@ mod tests {
     #[test]
     fn test_drop_empty() {
         ThinVec::<u8>::new();
+    }
+
+    #[test]
+    fn test_data_ptr_alignment() {
+        let v = ThinVec::<u16>::new();
+        assert!(v.data_raw() as usize % 2 == 0);
+
+        let v = ThinVec::<u32>::new();
+        assert!(v.data_raw() as usize % 4 == 0);
+
+        let v = ThinVec::<u64>::new();
+        assert!(v.data_raw() as usize % 8 == 0);
+    }
+
+    #[test]
+    #[cfg_attr(feature = "gecko-ffi", should_panic)]
+    fn test_overaligned_type_is_rejected_for_gecko_ffi_mode() {
+        #[repr(align(16))]
+        struct Align16(u8);
+
+        let v = ThinVec::<Align16>::new();
+        assert!(v.data_raw() as usize % 16 == 0);
     }
 
     #[test]


### PR DESCRIPTION
I've been running `MIRIFLAGS="-Zmiri-tag-raw-pointers" cargo miri test` on a number of crates, and I recently came across this one. Here's what I found:

* A `&Header` cannot be used to get a useful pointer to data beyond it, because the pointer from the as-cast of the `&Header` only has provenance over the `Header`.
* After a `set_len` call that decreases the length, it is invalid to create a slice then try to `get_unchecked` into the region between the old and new length, because the reference in the slice that the `ThinVec` now `Deref`s to does not have provenance over that region. Alternatively, this is UB because the docs stipulate that you're not allowed to use `get_unchecked` to index out of bounds.
* Misaligned data pointers were produced when the `gecko-ffi` feature was enabled and `T` has an alignment greater than 4.
* I think the use of `align_offset` in tests is subtly wrong, `align_offset` seems to be for optimizations only. The docs say that a valid implementation may always return `usize::MAX`.

FYI, the provenance issue here can be tricky to understand from Miri's output but [I have a Miri PR up](https://github.com/rust-lang/miri/pull/1971) that improves the diagnostics dramatically for cases like this. Also, I'm told this code might be shipped as part of a web browser? If an interested party wants to see if these issues affect a codebase that doesn't work under Miri [I have a rustc PR up](https://github.com/rust-lang/rust/pull/92686) which detects the alignment and `get_unchecked` issue when code is built with `-Zbuild-std`.