### PR TITLE
Add serde support (optional `serde` feature).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ default = []
 gecko-ffi = []
 
 [dependencies]
+serde = {version = "1.0", optional = true}
+
+[dev-dependencies]
+serde_test = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1222,9 +1222,9 @@ impl<'de, T: serde::Deserialize<'de>> serde::Deserialize<'de> for ThinVec<T> {
         use serde::de::{SeqAccess, Visitor};
         use serde::Deserialize;
 
-        struct ThinVecVisitor<'de, T: Deserialize<'de>>(PhantomData<(&'de (), T)>);
+        struct ThinVecVisitor<T>(PhantomData<T>);
 
-        impl<'de, T: Deserialize<'de>> Visitor<'de> for ThinVecVisitor<'de, T> {
+        impl<'de, T: Deserialize<'de>> Visitor<'de> for ThinVecVisitor<T> {
             type Value = ThinVec<T>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
This PR adds serialization via `serde::Serialize` and `serde::Deserialize`.

The de-serializer is guarded against malicious size hints, in the exact same manner as `serde`'s `Deserialize` `impl` for `Vec`.

The implementation was modeled off of `arrayvec`.