### PR TITLE
Optimize `clone` and `extend`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1267,8 +1267,18 @@ where
     T: Clone,
 {
     fn clone(&self) -> ThinVec<T> {
-        let mut new_vec = ThinVec::with_capacity(self.len());
-        new_vec.extend(self.iter().cloned());
+        let len = self.len();
+        let mut new_vec = ThinVec::<T>::with_capacity(len);
+        let mut data_raw = new_vec.data_raw();
+        for x in self.iter() {
+            unsafe {
+                ptr::write(data_raw, x.clone());
+                data_raw = data_raw.add(1);
+            }
+        }
+        unsafe {
+            new_vec.set_len(len); // could be the singleton
+        }
         new_vec
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1118,6 +1118,7 @@ impl<T> AsRef<[T]> for ThinVec<T> {
 }
 
 impl<T> Extend<T> for ThinVec<T> {
+    #[inline]
     fn extend<I>(&mut self, iter: I)
     where
         I: IntoIterator<Item = T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -900,7 +900,7 @@ impl<T> ThinVec<T> {
         self.extend(other.drain(..))
     }
 
-    pub fn drain<R>(&mut self, range: R) -> Drain<T>
+    pub fn drain<R>(&mut self, range: R) -> Drain<'_, T>
     where
         R: RangeBounds<usize>,
     {
@@ -1131,7 +1131,7 @@ impl<T> Extend<T> for ThinVec<T> {
 }
 
 impl<T: fmt::Debug> fmt::Debug for ThinVec<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
@@ -1292,7 +1292,7 @@ pub struct IntoIter<T> {
     start: usize,
 }
 
-pub struct Drain<'a, T: 'a> {
+pub struct Drain<'a, T> {
     iter: IterMut<'a, T>,
     vec: *mut ThinVec<T>,
     end: usize,


### PR DESCRIPTION
Some small performance wins I found while integrating `ThinVec` into rustc.