### PR TITLE
Optimize more for the empty case

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1134,7 +1134,10 @@ impl<T> Extend<T> for ThinVec<T> {
         I: IntoIterator<Item = T>,
     {
         let iter = iter.into_iter();
-        self.reserve(iter.size_hint().0);
+        let hint = iter.size_hint().0;
+        if hint > 0 {
+            self.reserve(hint);
+        }
         for x in iter {
             self.push(x);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1829,6 +1829,27 @@ mod tests {
             assert_eq!(v.capacity(), 0);
             assert_eq!(&v[..], &[]);
         }
+
+        {
+            let v = ThinVec::<i32>::new();
+            let v = v.clone();
+
+            assert_eq!(v.len(), 0);
+            assert_eq!(v.capacity(), 0);
+            assert_eq!(&v[..], &[]);
+        }
+    }
+
+    #[test]
+    fn test_clone() {
+        let mut v = ThinVec::<i32>::new();
+        assert!(v.is_singleton());
+        v.push(0);
+        v.pop();
+        assert!(!v.is_singleton());
+
+        let v2 = v.clone();
+        assert!(v2.is_singleton());
     }
 }
 


### PR DESCRIPTION
These commits optimize several operations better for the case where the `ThinVec` is empty. This is a common case for my use case of interest (in `rustc`) and is likely a pretty common case for `ThinVec` in general. (More so than `Vec`, for example.) It does slightly pessimize the non-empty cases, but only to the tune of a single branch per operation, which is hopefully acceptable.