### PR TITLE
Add missing unsafe block in ThinVec::is_singleton with gecko-ffi

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1533,7 +1533,7 @@ impl<T> ThinVec<T> {
     #[cfg(feature = "gecko-ffi")]
     #[inline]
     fn is_singleton(&self) -> bool {
-        self.ptr.as_ptr() as *const Header == &EMPTY_HEADER
+        unsafe { self.ptr.as_ptr() as *const Header == &EMPTY_HEADER }
     }
 
     #[cfg(not(feature = "gecko-ffi"))]


### PR DESCRIPTION
It was removed in 6e511609cd8eb10f70d12da8e2b99581ec318435 which seems to have been an accident.

Fixes #42