### PR TITLE
Add inline attributes on Header functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,11 +273,13 @@ struct Header {
 }
 
 impl Header {
+    #[inline]
     #[allow(clippy::unnecessary_cast)]
     fn len(&self) -> usize {
         self._len as usize
     }
 
+    #[inline]
     fn set_len(&mut self, len: usize) {
         self._len = assert_size(len);
     }


### PR DESCRIPTION
I saw that `len` didn't get inlined in `rustc` so these probably could use some `#[inline]` attributes.