### PR TITLE
Handle overflows in capacities more

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1541,7 +1541,12 @@ impl<T> ThinVec<T> {
 
     #[cfg(feature = "gecko-ffi")]
     #[inline]
+    #[allow(unused_unsafe)]
     fn is_singleton(&self) -> bool {
+        // NOTE: the tests will complain that this "unsafe" isn't needed, but it *IS*!
+        // In production this refers to an *extern static* which *is* unsafe to reference.
+        // In tests this refers to a local static because we don't have Firefox's codebase
+        // providing the symbol!
         unsafe { self.ptr.as_ptr() as *const Header == &EMPTY_HEADER }
     }
 


### PR DESCRIPTION
I was mentally applying the rule that capacity can never exceed isize::MAX as a precondition BUT this is the code necessary for enforcing that! In fixing this I broke the fact that this code was subtly relying on that overflow to allow usize::MAX ZSTs to be allocated (by only allocating space for the header). ZSTs previously actually worked fine, as the garbage overflowed value was always wiped out by multiplying by 0 to get the array size. Now we need to handle it more explicitly.

(also a driveby explanation for why #42 happened)