### PR TITLE
Add `has_capacity` as a proxy for `is_singleton`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -664,6 +664,11 @@ impl<T> ThinVec<T> {
         self.header().cap()
     }
 
+    /// Returns `true` if the vector has the capacity to hold any element.
+    pub fn has_capacity(&self) -> bool {
+        !self.is_singleton()
+    }
+
     /// Forces the length of the vector to `new_len`.
     ///
     /// This is a low-level operation that maintains none of the normal


### PR DESCRIPTION
This is useful since LLVM can omit the destructor if it knows `!has_capacity()`. It can be used to make https://github.com/rust-lang/rust/pull/108359 cleaner.