### PR TITLE
inline `cap`, `set_cap`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,11 +310,13 @@ impl Header {
 
 #[cfg(not(feature = "gecko-ffi"))]
 impl Header {
+    #[inline]
     #[allow(clippy::unnecessary_cast)]
     fn cap(&self) -> usize {
         self._cap as usize
     }
 
+    #[inline]
     fn set_cap(&mut self, cap: usize) {
         self._cap = assert_size(cap);
     }


### PR DESCRIPTION
For rustc these functions have over 1k call sites, considering size marked them as `inline`.