### PR TITLE
Use core::mem::align_of to determine proper type aligment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2657,13 +2657,13 @@ mod tests {
     #[test]
     fn test_data_ptr_alignment() {
         let v = ThinVec::<u16>::new();
-        assert!(v.data_raw() as usize % 2 == 0);
+        assert!(v.data_raw() as usize % core::mem::align_of::<u16>() == 0);
 
         let v = ThinVec::<u32>::new();
-        assert!(v.data_raw() as usize % 4 == 0);
+        assert!(v.data_raw() as usize % core::mem::align_of::<u32>() == 0);
 
         let v = ThinVec::<u64>::new();
-        assert!(v.data_raw() as usize % 8 == 0);
+        assert!(v.data_raw() as usize % core::mem::align_of::<u64>() == 0);
     }
 
     #[test]


### PR DESCRIPTION
On i686, the u64 test sometimes fails because the required alignment is
4-bytes, not 8-bytes.

Closes #56
Co-authored-by: Peter Michael Green <plugwash@debian.org>