### PR TITLE
Fix `unstable` feature.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,8 @@ jobs:
         run: MIRIFLAGS=-Zmiri-strict-provenance cargo miri test
       - name: Test (gecko-ffi) with Miri
         run: MIRIFLAGS=-Zmiri-strict-provenance cargo miri test --features=gecko-ffi
+      - name: Test (unstable features) with Miri
+        run: MIRIFLAGS=-Zmiri-strict-provenance cargo miri test --features=unstable
 
   build:
     runs-on: ubuntu-latest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@
 //! [pinned]: https://doc.rust-lang.org/std/pin/index.html
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "unstable", feature(trusted_len))]
 #![allow(clippy::comparison_chain, clippy::missing_safety_doc)]
 
 extern crate alloc;


### PR DESCRIPTION
Currently, enabling the `unstable` cargo feature of `thin-vec` does not enable the Rust nightly feature `trusted_len`, so `cargo +nightly build --features=unstable` always fails. This PR adds `#![cfg_attr(feature = "unstable", feature(trusted_len))]` to remedy that.

Alternately, the fact that this hasn't been reported may indicate that the `unstable` feature is not used in the wild and could just be removed (or leave the feature itself and only remove the two `TrustedLen` impls gated under it).