### PR TITLE
Implement `MallocSizeOf` for `thin-vec`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
+    - name: Build (malloc_size_of)
+      run: cargo build --features=malloc_size_of --verbose
     - name: Run tests
       run: cargo test --verbose
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ malloc_size_of = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(no_global_oom_handling)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "thin-vec"
-version = "0.2.13"
+version = "0.2.14"
 authors = ["Aria Beingessner <a.beingessner@gmail.com>"]
 description = "A vec that takes up less space on the stack"
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ std = []
 gecko-ffi = []
 
 [dependencies]
-serde = {version = "1.0", optional = true}
+serde = { version = "1.0", optional = true }
+malloc_size_of = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,6 @@
+# Version 0.2.14 (2025-02-19)
+* Add "malloc_size_of" feature for heap size measurement support
+
 # Version 0.2.13 (2023-12-02)
 
 * add default-on "std" feature for no_std support


### PR DESCRIPTION
Now that [malloc_size_of](https://github.com/servo/malloc_size_of) is published to crates.io we are moving the trait implementations of [MallocSizeOf](https://docs.rs/malloc_size_of/latest/malloc_size_of/trait.MallocSizeOf.html) and related traits into the crates that define the types. This will avoid the situation where depending on `malloc_size_of` pulls in a large number of dependencies, and is needed for ongoing use of this crate by the Servo and Gecko projects.

This PR adds the implementation of `MallocSizeOf` to the `thin-vec` crate.