### PR TITLE
feat: add `const_new` feature for const `ThinVec::new()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.53"
 unstable = []
 default = ["std"]
 std = []
+const_new = []
 
 # Gecko specific features. These features cause thin-vec to have the same layout
 # and behaviour as nsTArray, allowing it to be used in C++ FFI. Requires

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,14 @@
 //!   but it could be done if someone cared enough to implement it.
 //!
 //!
+//! # Optional Features
+//!
+//! ## `const_new`
+//!
+//! **This feature requires Rust 1.83.**
+//!
+//! This feature makes `ThinVec::new()` a `const fn`.
+//!
 //!
 //! # Gecko FFI
 //!
@@ -516,8 +524,22 @@ impl<T> ThinVec<T> {
     /// Creates a new empty ThinVec.
     ///
     /// This will not allocate.
+    #[cfg(not(feature = "const_new"))]
     pub fn new() -> ThinVec<T> {
         ThinVec::with_capacity(0)
+    }
+
+    /// Creates a new empty ThinVec.
+    ///
+    /// This will not allocate.
+    #[cfg(feature = "const_new")]
+    pub const fn new() -> ThinVec<T> {
+        unsafe {
+            ThinVec {
+                ptr: NonNull::new_unchecked(&EMPTY_HEADER as *const Header as *mut Header),
+                boo: PhantomData,
+            }
+        }
     }
 
     /// Constructs a new, empty `ThinVec<T>` with at least the specified capacity.


### PR DESCRIPTION
This adds a new optional feature `const_new` that makes `ThinVec::new()` a const fn when enabled. The feature requires Rust 1.83 or later.

fixes #54 