### PR TITLE
Update repository URL and various cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-edition = "2018"
 name = "thin-vec"
 version = "0.2.15"
 authors = ["Aria Beingessner <a.beingessner@gmail.com>"]
-description = "A vec that takes up less space on the stack"
-license = "MIT/Apache-2.0"
-repository = "https://github.com/gankra/thin-vec"
-homepage = "https://github.com/gankra/thin-vec"
-readme = "README.md"
+edition = "2018"
 rust-version = "1.53"
+description = "A Vec that takes up less space on the stack."
+readme = "README.md"
+homepage = "https://github.com/mozilla/thin-vec"
+repository = "https://github.com/mozilla/thin-vec"
+license = "MIT OR Apache-2.0"
 
 [features]
 unstable = []

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Rust CI](https://github.com/Gankra/thin-vec/workflows/Rust/badge.svg?branch=master) [![crates.io](https://img.shields.io/crates/v/thin-vec.svg)](https://crates.io/crates/thin-vec) [![](https://docs.rs/thin-vec/badge.svg)](https://docs.rs/thin-vec)
+[![Rust CI](https://github.com/mozilla/thin-vec/actions/workflows/rust.yml/badge.svg)](https://github.com/mozilla/thin-vec/actions) [![crates.io](https://img.shields.io/crates/v/thin-vec.svg)](https://crates.io/crates/thin-vec) [![Docs](https://docs.rs/thin-vec/badge.svg)](https://docs.rs/thin-vec)
 
 # thin-vec
 
@@ -6,4 +6,4 @@ ThinVec is a Vec that stores its length and capacity inline, making it take up
 less space.
 
 Currently this crate mostly exists to facilitate Gecko (Firefox) FFI, but it
-works perfectly fine as a native rust library as well.
+works perfectly fine as a native Rust library as well.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,11 +1,11 @@
-# Version 0.2.15 (2025-02-19)
-* Support AutoTArrays created from rust in Gecko FFI mode.
+# Version 0.2.15 (2026-04-08)
+* Support AutoTArrays created from Rust in Gecko FFI mode.
 * Add extract_if.
 * Add const new() support behind feature flag.
 * Fix `thin_vec` macro not being hygienic when recursing
 * Improve extend() performance.
 
-# Version 0.2.14 (2025-02-19)
+# Version 0.2.14 (2025-03-23)
 * Add "malloc_size_of" feature for heap size measurement support
 
 # Version 0.2.13 (2023-12-02)
@@ -14,7 +14,7 @@
 * added has_capacity method for checking if something is the empty singleton
 * marked more things as `#[inline]`
 * added license files
-* appeased clippy
+* appeased Clippy
 
 # Previous Versions
 


### PR DESCRIPTION
- Update repository as https://github.com/mozilla/thin-vec
- Use SPDX license format
- Correct release dates in RELEASES.md
- Some minor formatting cleanups