### PR TITLE
Prefer core::marker and core::mem to fix `--no-default-features -F malloc_size_of`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2138,8 +2138,8 @@ impl<T> MallocShallowSizeOf for ThinVec<T> {
         }
 
         assert_eq!(
-            std::mem::size_of::<Self>(),
-            std::mem::size_of::<*const ()>()
+            core::mem::size_of::<Self>(),
+            core::mem::size_of::<*const ()>()
         );
         unsafe { ops.malloc_size_of(*(self as *const Self as *const *const ())) }
     }


### PR DESCRIPTION
hello again :upside_down_face: 

as a followup to #82, I unfortunately noticed I missed there's one more feature with the same issue. I already applied this downstream and uploaded 0.2.17 to Debian, but wanted to leave this here for inclusion anyway (not asking for a release right now, it's fine if this is part of the next regular release).

Sorry and thanks!