### PR TITLE
Add may_dangle Drop impl under the unstable flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "unstable", feature(trusted_len))]
+#![cfg_attr(feature = "unstable", feature(dropck_eyepatch))]
 #![allow(clippy::comparison_chain, clippy::missing_safety_doc)]
 
 extern crate alloc;
@@ -1934,7 +1935,18 @@ fn drop_non_singleton<T>(this: &mut ThinVec<T>) {
     }
 }
 
+#[cfg(not(feature = "unstable"))]
 impl<T> Drop for ThinVec<T> {
+    #[inline]
+    fn drop(&mut self) {
+        if !self.is_singleton() {
+            drop_non_singleton(self);
+        }
+    }
+}
+
+#[cfg(feature = "unstable")]
+unsafe impl<#[may_dangle] T> Drop for ThinVec<T> {
     #[inline]
     fn drop(&mut self) {
         if !self.is_singleton() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1920,23 +1920,23 @@ impl<T: PartialEq> ThinVec<T> {
     }
 }
 
+#[cold]
+#[inline(never)]
+fn drop_non_singleton<T>(this: &mut ThinVec<T>) {
+    unsafe {
+        ptr::drop_in_place(&mut this[..]);
+
+        if this.uses_stack_allocated_buffer() {
+            return;
+        }
+
+        dealloc(this.ptr() as *mut u8, layout::<T>(this.capacity()))
+    }
+}
+
 impl<T> Drop for ThinVec<T> {
     #[inline]
     fn drop(&mut self) {
-        #[cold]
-        #[inline(never)]
-        fn drop_non_singleton<T>(this: &mut ThinVec<T>) {
-            unsafe {
-                ptr::drop_in_place(&mut this[..]);
-
-                if this.uses_stack_allocated_buffer() {
-                    return;
-                }
-
-                dealloc(this.ptr() as *mut u8, layout::<T>(this.capacity()))
-            }
-        }
-
         if !self.is_singleton() {
             drop_non_singleton(self);
         }


### PR DESCRIPTION
We use ThinVec quite a bit in the compiler, but there are cases where we can't, because it doesn't have `#[may_dangle]` on `T`. This is a case I recently encountered for example: https://github.com/rust-lang/rust/blob/ae3bbe78ec2a9bb57a03f10ad6ee0388e12bcefb/compiler/rustc_middle/src/mir/statement.rs#L1041

This PR adds the Drop impl under the existing `unstable` feature flag. I moved the cold drop function out of it to avoid duplicating too much code.

I followed a similar pattern as in https://github.com/servo/rust-smallvec/pull/133, which did the same for smallvec (motivated by the compiler, too)
